### PR TITLE
fix for e2e test, little improvement in bash script

### DIFF
--- a/pkg/signature/kms/kms.go
+++ b/pkg/signature/kms/kms.go
@@ -28,7 +28,7 @@ import (
 )
 
 func init() {
-	ProvidersMux().AddProvider(hashivault.ReferenceScheme, func(ctx context.Context, keyResourceID string, hashFunc crypto.Hash) (SignerVerifier, error) {
+	ProvidersMux().AddProvider(azure.ReferenceScheme, func(ctx context.Context, keyResourceID string, hashFunc crypto.Hash) (SignerVerifier, error) {
 		return azure.LoadSignerVerifier(ctx, keyResourceID, hashFunc)
 	})
 	ProvidersMux().AddProvider(gcp.ReferenceScheme, func(ctx context.Context, keyResourceID string, _ crypto.Hash) (SignerVerifier, error) {

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   vault:
     image: vault:latest
     environment:
-      VAULT_DEV_ROOT_TOKEN_ID: testtoken
+      VAULT_DEV_ROOT_TOKEN_ID: ${VAULT_TOKEN}
     ports:
       - 8200:8200
     privileged: true

--- a/test/e2e/e2e-test.sh
+++ b/test/e2e/e2e-test.sh
@@ -16,7 +16,18 @@
 
 set -ex
 
+cleanup() {
+  echo "cleanup"
+  docker-compose down
+}
+
+trap cleanup ERR
+
+export VAULT_TOKEN=testtoken
+export VAULT_ADDR=http://localhost:8200/
+
 echo "starting services"
+docker-compose config
 docker-compose up -d
 
 count=0
@@ -39,10 +50,6 @@ sleep 5
 echo
 echo "running tests"
 
-export VAULT_TOKEN=testtoken
-export VAULT_ADDR=http://localhost:8200/
-
 go test -tags e2e -count=1 ./...
 
-echo "cleanup"
-docker-compose down
+cleanup


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

re-opened against `azure-kms` branch, duplicate with #1.